### PR TITLE
Improve display of blocks with several top-level elements

### DIFF
--- a/history/history.js
+++ b/history/history.js
@@ -382,7 +382,7 @@ function mapElements(o, fn, args, joinStr) {
 function blockToMd(block, args) {
   switch (block.type) {
     case 'rich_text':
-      return mapElements(block, elementToMd, args, '');
+      return mapElements(block, elementToMd, args, '\n\n');
     default:
       console.warn('Unknown type', block.type, block);
       return `Unknown type ${block.type}`;


### PR DESCRIPTION
This changes the history viewer to add new lines between top-level elements of a block, which improves the Markdown to HTML conversion for cases where you have e.g. a quote followed by regular text.

As a specific example, [this message](https://marianoguerra.github.io/future-of-coding-weekly/history/weekly/2021/06/W1/thinking-together.html#2021-06-05T22:33:17.041Z) current looks like:

![image](https://user-images.githubusercontent.com/279572/121006414-c8023680-c788-11eb-8cde-aca78d715cee.png)

After the changes here, it looks like:

![image](https://user-images.githubusercontent.com/279572/121006472-d6e8e900-c788-11eb-80ad-d031a8fff0cf.png)